### PR TITLE
hotfix: create user before setting session

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -26,7 +26,7 @@ export const authCheck = ash(async (req, res) => {
   if (!user) {
     return res.status(404).json({ error: "User not found" });
   }
-  
+
   const groupApplies = await GroupApply.find(
     { members: { $elemMatch: { user: user._id } } },
     {
@@ -196,15 +196,6 @@ export const loginCallback = ash(async (req, res) => {
     })
     .populate("boards");
 
-  // set req.session.isAdmin, req.session.adminId when user login
-  if (user.isAdmin) {
-    req.session.isAdmin = true;
-    req.session.adminId = user._id;
-  } else {
-    req.session.isAdmin = false;
-    req.session.adminId = null;
-  }
-
   // User wants to refresh SSO data
   if (update) {
     if (!user) {
@@ -218,6 +209,15 @@ export const loginCallback = ash(async (req, res) => {
   }
   if (!user) {
     user = await register(userData);
+  }
+
+  // set req.session.isAdmin, req.session.adminId when user login
+  if (user.isAdmin) {
+    req.session.isAdmin = true;
+    req.session.adminId = user._id;
+  } else {
+    req.session.isAdmin = false;
+    req.session.adminId = null;
   }
 
   const groupApplies = await GroupApply.find(


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

<!-- 같은 레포의 이슈를 해결할 경우엔 "closes", 다른 레포의 이슈를 해결할 경우엔 "fixes", 여러 개의 이슈를 해결할 경우엔 "resolves"를 사용할 수 있습니다. -->

유저가 처음 사이트를 방문하는 경우, 유저객체를 생성하기 전에 유저 객체의 isAdmin을 읽고 세션을 세팅하였다. 
유저 객체를 생성한 뒤에 유저의 isAdmin field을 읽도록 바꾸었다.

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

