### PR TITLE
Dev, Prod docker-compose 파일 분리

### DIFF
--- a/.docker/docker-compose.stage.yml
+++ b/.docker/docker-compose.stage.yml
@@ -4,7 +4,7 @@ services:
   zabo-server:
     container_name: zabo-server
     restart: always
-    image: ghcr.io/sparcs-kaist/zabo-server:latest
+    image: ghcr.io/sparcs-kaist/zabo-server:dev
     ports:
       - "${SERVER_PORT}:6001"
     depends_on:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev:db:down": "yarn docker:dev down",
     "dev:db:attach": "docker exec -it zabo-mongo-dev /bin/bash",
     "docker:dev": "docker compose -f .docker/docker-compose.dev.yml -p zabo-dev --env-file=.docker/.env.development",
-    "docker:prod": "docker compose -f .docker/docker-compose.yml -p zabo --env-file=.docker/.env.prod up",
+    "docker:stage": "docker compose -f .docker/docker-compose.stage.yml -p zabo --env-file=.docker/.env.prod",
+    "docker:prod": "docker compose -f .docker/docker-compose.yml -p zabo --env-file=.docker/.env.prod",
     "prod": "yarn env:prod nodemon index",
     "seed": "node tools/seed"
   },


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #122 
자동배포 도입 전 해결할 이슈입니다.
개발용 서버(`dev`)와 프로덕션 서버(`latest`)가 사용할 이미지의 태그가 다르기 때문에, docker compose 파일을 분리하였습니다.
- docker-compose.stage.ym : 개발 서버용 (기존 docker-compose.dev.yml과 겹치지 않는 파일명을 선택했습니다)
- docker-compose.yml : 프로덕션 서버용

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

없음.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- dev, prod 자동 배포
