### PR TITLE
dev, prod 서버 자동 배포 추가

### DIFF
--- a/.github/workflows/dev-build-image.yaml
+++ b/.github/workflows/dev-build-image.yaml
@@ -1,0 +1,36 @@
+name: Build docker image on push to develop
+
+on:
+  push:
+    branches: ["develop"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Log in to GitHub Container Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u USERNAME --password-stdin
+      - name: Build and push Image
+        id: docker-build
+        uses: docker/build-push-action@v5
+        env:
+          IMAGE_TAG: dev
+        with:
+          push: true
+          tags: "ghcr.io/sparcs-kaist/zabo-server:${{ env.IMAGE_TAG }}"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Remove old cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -1,0 +1,32 @@
+name: Deploy to dev server
+
+# when dev image build action is completed, run this action
+on:
+  workflow_run:
+    workflows: ["Build docker image on push to develop"]
+    types:
+      - completed
+
+jobs:
+  if_workflow_success:
+    name: Deploy to dev server
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: pull the image and restart the container
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          port: ${{ secrets.DEV_PORT }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          proxy_host: ${{ secrets.DEV_PROXY_HOST }}
+          proxy_port: ${{ secrets.DEV_PROXY_PORT }}
+          proxy_username: ${{ secrets.DEV_PROXY_USERNAME }}
+          proxy_password: ${{ secrets.DEV_PROXY_PASSWORD }}
+          script_stop: true # stop script if any command has failed
+          script: |
+            cd ${{ secrets.DEV_WORKING_DIRECTORY }}
+            docker compose -f .docker/docker-compose.stage.yml -p zabo --env-file=.docker/.env.prod pull
+            docker compose -f .docker/docker-compose.stage.yml -p zabo --env-file=.docker/.env.prod up --force-recreate --build -d

--- a/.github/workflows/prod-build-image.yaml
+++ b/.github/workflows/prod-build-image.yaml
@@ -1,0 +1,40 @@
+name: Build docker image on release tag created
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  build:
+    name: Build and push Image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Log in to GitHub Container Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u USERNAME --password-stdin
+      - name: Build and push Image
+        id: docker-build
+        uses: docker/build-push-action@v5
+        env:
+          IMAGE_TAG: ${{github.ref_name}}
+        with:
+          push: true
+          tags: |
+            "ghcr.io/sparcs-kaist/zabo-server:${{ env.IMAGE_TAG }}"
+            "ghcr.io/sparcs-kaist/zabo-server:latest"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Remove old cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/prod-deploy.yaml
+++ b/.github/workflows/prod-deploy.yaml
@@ -1,0 +1,32 @@
+name: Deploy to prod server
+
+# when prod image build action is completed, run this action
+on:
+  workflow_run:
+    workflows: ["Build docker image on release tag created"]
+    types:
+      - completed
+
+jobs:
+  if_workflow_success:
+    name: Deploy to prod server
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: pull the image and restart the container
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          port: ${{ secrets.PROD_PORT }}
+          username: ${{ secrets.PROD_USERNAME }}
+          password: ${{ secrets.PROD_PASSWORD }}
+          proxy_host: ${{ secrets.PROD_PROXY_HOST }}
+          proxy_port: ${{ secrets.PROD_PROXY_PORT }}
+          proxy_username: ${{ secrets.PROD_PROXY_USERNAME }}
+          proxy_password: ${{ secrets.PROD_PROXY_PASSWORD }}
+          script_stop: true # stop script if any command has failed
+          script: |
+            cd ${{ secrets.PROD_WORKING_DIRECTORY }}
+            yarn docker:prod pull
+            yarn docker:prod up --force-recreate --build -d


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #121 
- develop 브랜치에 새 커밋이 생성될 때마다 Github container registry를 통해 이미지를 빌드하고, 이를 dev 서버에 자동 배포합니다.
- 새 release가 생성될 때마다 Github container registry를 통해 이미지를 빌드하고, 이를 prod 서버에 자동 배포합니다.

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

없음.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- dev, prod 서버 배포 오류 시 이슈를 다시 열어야 합니다.
