### PR TITLE
[Bug] Remove `yarn` command from github action (prod-deploy)

### DIFF
--- a/.github/workflows/prod-deploy.yaml
+++ b/.github/workflows/prod-deploy.yaml
@@ -28,5 +28,5 @@ jobs:
           script_stop: true # stop script if any command has failed
           script: |
             cd ${{ secrets.PROD_WORKING_DIRECTORY }}
-            yarn docker:prod pull
-            yarn docker:prod up --force-recreate --build -d
+            docker compose -f .docker/docker-compose.yml -p zabo --env-file=.docker/.env.prod pull
+            docker compose -f .docker/docker-compose.yml -p zabo --env-file=.docker/.env.prod up --force-recreate --build -d


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #128 

ssh 사용 시 .zshrc 파일이 적용되지 않아 `yarn` 실행 파일 경로를 찾을 수 없습니다.
`yarn docker:prod` 대신 기존 docker-compose 커맨드를 사용하여 프로덕션 서버에 배포를 진행합니다.

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

Release 0.1.4에 포함할 예정입니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
